### PR TITLE
Issues 42, 43, 44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN python3 -m venv $VIRTUAL_ENV && \
 
 USER $USERNAME
 
-COPY --chown=${USER_UID}:${USER_GID} . .
+# prevent full rebuilds every time code changes
+COPY --chown=${USER_UID}:${USER_GID} pyproject.toml poetry.lock README.md /code/
+COPY --chown=${USER_UID}:${USER_GID} starling/__init__.py /code/starling/__init__.py
 
 RUN poetry install --with docs,dev
+
+COPY . .

--- a/starling/starling.py
+++ b/starling/starling.py
@@ -160,8 +160,8 @@ class ST(pl.LightningModule):
             self.adata.uns["init_cell_size_variances"] = np.array(init_sv)
         else:
             # init_cell_size_centroids = None; init_cell_size_variances = None
-            self.adata.varm["init_cell_size_centroids"] = None
-            self.adata.varm["init_cell_size_variances"] = None
+            self.adata.uns["init_cell_size_centroids"] = None
+            self.adata.uns["init_cell_size_variances"] = None
             self.train_df = utility.ConcatDataset([self.X, tr_fy, tr_fl])
 
         # model_params = utility.model_paramters(self.init_e, self.init_v, self.init_s, self.init_sv)
@@ -397,9 +397,9 @@ class ST(pl.LightningModule):
         # else:
         c = self.model_params["log_mu"].detach().exp().cpu().numpy()
         # v = self.model_params['log_sigma'].cpu().detach().exp().cpu().numpy()
-        self.adata.varm[
-            "st_exp_centroids"
-        ] = c.T  # pd.DataFrame(c, columns=self.adata.var_names)
+        self.adata.varm["st_exp_centroids"] = (
+            c.T
+        )  # pd.DataFrame(c, columns=self.adata.var_names)
 
         if self.model_cell_size:
             self.adata.uns["st_cell_size_centroids"] = (

--- a/starling/starling.py
+++ b/starling/starling.py
@@ -397,9 +397,9 @@ class ST(pl.LightningModule):
         # else:
         c = self.model_params["log_mu"].detach().exp().cpu().numpy()
         # v = self.model_params['log_sigma'].cpu().detach().exp().cpu().numpy()
-        self.adata.varm["st_exp_centroids"] = (
-            c.T
-        )  # pd.DataFrame(c, columns=self.adata.var_names)
+        self.adata.varm[
+            "st_exp_centroids"
+        ] = c.T  # pd.DataFrame(c, columns=self.adata.var_names)
 
         if self.model_cell_size:
             self.adata.uns["st_cell_size_centroids"] = (

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,8 +1,8 @@
 from os.path import dirname, join
 
 import anndata as ad
+import numpy as np
 import pandas as pd
-import pytorch_lightning as pl
 from lightning_lite import seed_everything
 from pytorch_lightning.callbacks import EarlyStopping
 
@@ -10,7 +10,7 @@ from starling import starling, utility
 
 
 def test_can_run_km(tmpdir):
-    """Temporary sanity check"""
+    """Test that we can run with the KM setting in init_clustering"""
     seed_everything(10, workers=True)
 
     raw_adata = ad.read_h5ad(join(dirname(__file__), "fixtures", "sample_input.h5ad"))
@@ -51,7 +51,7 @@ def test_can_run_km(tmpdir):
 
 
 def test_can_run_gmm(tmpdir):
-    """Temporary sanity check"""
+    """Test that we can run with the GMM setting in init_clustering"""
     seed_everything(10, workers=True)
     adata = utility.init_clustering(
         "GMM",
@@ -89,7 +89,7 @@ def test_can_run_gmm(tmpdir):
 
 
 def test_can_run_pg(tmpdir):
-    """Temporary sanity check"""
+    """Test that we can run with the PG setting in init_clustering"""
     seed_everything(10, workers=True)
     adata = utility.init_clustering(
         "PG",
@@ -111,7 +111,6 @@ def test_can_run_pg(tmpdir):
     ## initial expression centriods (p x c) matrix
     init_cent = pd.DataFrame(result.varm["init_exp_centroids"], index=result.var_names)
 
-    # j seems to vary here
     assert init_cent.shape[0] == 24
 
     ## starling expression centriods (p x c) matrix
@@ -126,8 +125,9 @@ def test_can_run_pg(tmpdir):
 
     assert prom_mat.shape[0] == 13685
 
+
 def test_can_run_pg_without_cell_size(tmpdir):
-    """Temporary sanity check"""
+    """Test that we can run the model with model_cell_size=False in ST"""
     seed_everything(10, workers=True)
     adata = utility.init_clustering(
         "PG",
@@ -146,4 +146,6 @@ def test_can_run_pg_without_cell_size(tmpdir):
 
     result = st.result()
 
-    assert True
+    exp_cent = pd.DataFrame(result.varm["st_exp_centroids"], index=result.var_names)
+
+    assert exp_cent.shape[0] == 24

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -125,3 +125,25 @@ def test_can_run_pg(tmpdir):
     )
 
     assert prom_mat.shape[0] == 13685
+
+def test_can_run_pg_without_cell_size(tmpdir):
+    """Temporary sanity check"""
+    seed_everything(10, workers=True)
+    adata = utility.init_clustering(
+        "PG",
+        ad.read_h5ad(join(dirname(__file__), "fixtures", "sample_input.h5ad")),
+        k=10,
+    )
+    st = starling.ST(adata, model_cell_size=False)
+    cb_early_stopping = EarlyStopping(monitor="train_loss", mode="min", verbose=False)
+
+    ## train ST
+    st.train_and_fit(
+        max_epochs=2,
+        callbacks=[cb_early_stopping],
+        default_root_dir=tmpdir,
+    )
+
+    result = st.result()
+
+    assert True

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -1,3 +1,4 @@
+import numpy as np
 from anndata import AnnData
 
 from starling.utility import init_clustering, validate_starling_arguments
@@ -6,9 +7,11 @@ from starling.utility import init_clustering, validate_starling_arguments
 def assert_annotated(adata: AnnData, k):
     assert "init_exp_centroids" in adata.varm
     assert adata.varm["init_exp_centroids"].shape == (adata.X.shape[1], k)
+    assert not np.any(np.isnan(adata.varm["init_exp_centroids"]))
 
     assert "init_exp_centroids" in adata.varm
     assert adata.varm["init_exp_variances"].shape == (adata.X.shape[1], k)
+    assert not np.any(np.isnan(adata.varm["init_exp_variances"]))
 
     assert "init_label" in adata.obs
     assert adata.obs["init_label"].shape == (adata.X.shape[0],)
@@ -29,6 +32,25 @@ def test_init_clustering_gmm(simple_adata):
 def test_init_clustering_pg(simple_adata):
     k = 2
     initialized = init_clustering("PG", simple_adata, k)
+    assert_annotated(initialized, k)
+
+
+def test_init_clustering_user(simple_adata):
+    k = 3
+    initialized = init_clustering(
+        "User", simple_adata, labels=np.random.randint(k, size=32)
+    )
+    assert_annotated(initialized, k)
+
+
+def test_init_clustering_user_string(simple_adata):
+    k = 3
+    initialized = init_clustering(
+        "User",
+        simple_adata,
+        labels=np.random.choice(np.array(["a", "b", "c"]), size=32),
+    )
+
     assert_annotated(initialized, k)
 
 


### PR DESCRIPTION
- Address #42 by setting null values on `adata.uns`. Change [here](https://github.com/camlab-bioml/starling/compare/cklamann/bugfixes?expand=1#diff-7104aab60b4446d51aa0366650fcf15ebeb8db838058b17a056a0a4b9d77fc29R163-R164), test [here](https://github.com/camlab-bioml/starling/compare/cklamann/bugfixes?expand=1#diff-7eae1f5302e2bd8f498dafe1fcce77569994b10488c40410c0e1014d0a5f5d15R127-R151)
- Address #43 by making `k` not required  and updating argument validation checks. Test [here](https://github.com/camlab-bioml/starling/compare/cklamann/bugfixes?expand=1#diff-9fae3273f3494b7f7bac6e2e62122c81813b459dd1e9bff0b4870a9d3d5fac7eR38-R43).
- Address #44 by iterating with indices. Relevant code [here](https://github.com/camlab-bioml/starling/compare/cklamann/bugfixes?expand=1#diff-7266b862e10f9aa8164a51f1ebc58ee48618f853fafea08c1d39f1067ab069adR99-R105), test [here](https://github.com/camlab-bioml/starling/compare/cklamann/bugfixes?expand=1#diff-9fae3273f3494b7f7bac6e2e62122c81813b459dd1e9bff0b4870a9d3d5fac7eR46-R56).